### PR TITLE
Add composite capability to handle sizable bitmaps

### DIFF
--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -979,8 +979,8 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 		spec *Spec
 	}{
 		{
-			desc: "panics on nil Tag being defined in spec",
-			err:  "Composite spec requires a Tag.Sort function to be defined",
+			desc: "panics on nil Tag and no Bitmap being defined in spec",
+			err:  "Composite spec requires a Tag.Sort function or a BitmapSpec to be defined",
 			spec: &Spec{
 				Length:    6,
 				Pref:      prefix.ASCII.Fixed,
@@ -989,8 +989,8 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 			},
 		},
 		{
-			desc: "panics on nil Tag.Sort being defined in spec",
-			err:  "Composite spec requires a Tag.Sort function to be defined",
+			desc: "panics on nil Tag and no Bitmap being defined in spec",
+			err:  "Composite spec requires a Tag.Sort function or a BitmapSpec to be defined",
 			spec: &Spec{
 				Length:    6,
 				Pref:      prefix.ASCII.Fixed,

--- a/field/spec.go
+++ b/field/spec.go
@@ -55,6 +55,9 @@ type Spec struct {
 	// Subfields defines the subfields held within the field. Only
 	// applicable to composite field types.
 	Subfields map[string]Field
+	// BitmapOptions could be used on a bitmap field, and is optional.
+	// Contains options that modifies the behaviour of the bitmap.
+	BitmapOptions *BitmapOptions
 }
 
 func NewSpec(length int, desc string, enc encoding.Encoder, pref prefix.Prefixer) *Spec {


### PR DESCRIPTION
This PR has two parts:

- Bitmaps with options feature:
The idea is to have a way to modify the bitmap behaviour using the Spec when we initialize one, this behaviour could be the maximum bitmaps blocks that a bitmap is allowed to have or to expand, and the bitmap block size that a bitmap have to expect.

- Composites with bitmaps:
We encounter some cases where apart from having subfields, each subfield existante is determined by a bitmap.
So we had to expand the composite implementation to expect bitmaps before its subfields and understand it for knowing which subfields has to unpack.